### PR TITLE
feature/texturepack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,3 @@ REMOTE_FASTDL_DIR=/var/www/html/cstrike/maps
 REMOTE_MAP_DIR=/home/cssserver/serverfiles/cstrike/maps
 
 RCON_PASS=rcon123
-
-BSPZIP_PATH=C:/Program Files (x86)/Steam/steamapps/common/Counter-Strike Source/bin
-BSPZIP_RESFILE=res.txt

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ REMOTE_FASTDL_DIR=/var/www/html/cstrike/maps
 REMOTE_MAP_DIR=/home/cssserver/serverfiles/cstrike/maps
 
 RCON_PASS=rcon123
+
+BSPZIP_PATH=C:/Program Files (x86)/Steam/steamapps/common/Counter-Strike Source/bin
+BSPZIP_RESFILE=res.txt

--- a/app.js
+++ b/app.js
@@ -238,7 +238,6 @@ var bspsync = async.queue((task, callback) => {
 						});
 					});
 				});
-				return callback(false);
 			});
 
 			// Update metadata and write back.

--- a/app.js
+++ b/app.js
@@ -72,6 +72,12 @@ const output_server = {
 	}
 };
 
+const bspzip_path = process.env.BSPZIP_PATH.concat(path.sep + 'bspzip.exe');
+const bspzip_resfile = process.env.BSPZIP_RESFILE;
+
+if (!fs.existsSync(bspzip_path))
+	console.error(`fatal error: '${bspzip_path}' is missing.`);
+
 // Ensure all the required external dependencies exist.
 const bin_folder = path.resolve('./bin').concat(path.sep);
 
@@ -139,6 +145,13 @@ var bspsync = async.queue((task, callback) => {
 		fs.rename(input_file, output_file, error => {
 			if (error)
 				return callback(new Error('failed to move map to output directory.'));
+
+			console.log(`packing textures into '${output_filename}..'`);
+
+			child_process.spawn(bspzip_path, ['-addlist', output_file, bspzip_resfile, output_file], {cwd: bin_folder}).on('close', code => {
+				if (code !== 0)
+					return callback(new Error('failed to pack map textures'));
+			});
 
 			console.log(`compressing '${output_filename}' for fastdl..`);
 


### PR DESCRIPTION
adds --quickpack flag to use https://github.com/cannon/quickpack to pack custom resources
invokes with python env as it's a python script - however, it's a little bit annoying because the script requires python27 why would you not python3! :P

so, QuickPack.py goes in ./bin and os must have python envvar pointing at a python2 interpreter

other main caveat is that quickpack only works when watching the source game's map path - so needs copy to game directory checked in hammer (example: C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Source\cstrike\maps)